### PR TITLE
Remove empty nodes from result file

### DIFF
--- a/src/main/kotlin/org/rnazarevych/lokalise/DocumentEx.kt
+++ b/src/main/kotlin/org/rnazarevych/lokalise/DocumentEx.kt
@@ -1,0 +1,21 @@
+package org.rnazarevych.lokalise
+
+import org.w3c.dom.Document
+import org.w3c.dom.Node
+import org.w3c.dom.NodeList
+import javax.xml.xpath.XPath
+import javax.xml.xpath.XPathConstants
+import javax.xml.xpath.XPathFactory
+
+const val EMPTY_NODE_EXPRESSION = "//text()[normalize-space(.)='']"
+
+fun Document.removeEmptyNodes() {
+    val xp: XPath = XPathFactory.newInstance().newXPath()
+    val nodes: NodeList = xp.evaluate(EMPTY_NODE_EXPRESSION, this, XPathConstants.NODESET) as NodeList
+    for (i in 0 until nodes.getLength()) {
+        val node: Node = nodes.item(i)
+        if (node.textContent.trim().isEmpty()) {
+            node.getParentNode().removeChild(node)
+        }
+    }
+}

--- a/src/main/kotlin/org/rnazarevych/lokalise/tasks/TranslationWriter.kt
+++ b/src/main/kotlin/org/rnazarevych/lokalise/tasks/TranslationWriter.kt
@@ -1,6 +1,7 @@
 package org.rnazarevych.lokalise.tasks
 
 import org.rnazarevych.lokalise.api.dto.TranslationsResponse
+import org.rnazarevych.lokalise.removeEmptyNodes
 import org.w3c.dom.Element
 import java.io.File
 import java.time.LocalDateTime
@@ -70,7 +71,6 @@ internal class TranslationWriter {
         println("Writing ${languageKeys.size} new entries")
         if (languageKeys.isNotEmpty()) {
             xmlDoc.documentElement.appendChild(xmlDoc.createComment("New translations added at ${LocalDateTime.now()}"))
-            xmlDoc.documentElement.appendChild(xmlDoc.createComment("\n"))
             languageKeys.forEach { key ->
                 key.translations.find { it.languageIso == lang }?.let { translation ->
                     val newNode = xmlDoc.documentElement.appendChild(xmlDoc.createElement("string")) as Element
@@ -80,6 +80,8 @@ internal class TranslationWriter {
                 }
             }
         }
+
+        xmlDoc.removeEmptyNodes()
 
         println("Writing to file")
 


### PR DESCRIPTION
Its possible to restrict TransformerFactory to add additional
whitespaces setting setOutputProperty(OutputKeys.INDENT, "no").
But this way newly added nodes will be in line.
So, fastest way to remove empty nodes is using XPath